### PR TITLE
fix(be): fix unlinked links in prisma study docs

### DIFF
--- a/content/docs/backend/7. Prisma.md
+++ b/content/docs/backend/7. Prisma.md
@@ -19,18 +19,18 @@ ORM의 의미와, Prisma가 어떤 서비스인지 한 번 알아봅시다!
 
 - [ORM이 뭘까?](https://velog.io/@gndan4/ORM이란): ORM이 뭔지 간단히 알아봅시다!
     - 이외에도 구글링하면 ORM에 대해서 많은 정보들이 나오니 참고해주세요! 😀
-- [Is Prisma an ORM?](https://www.prisma.io/docs/concepts/overview/prisma-in-your-stack/is-prisma-an-orm): Prisma 공식문서에서 Prisma가 무엇인지, 어떤 원리로 작동되는지에 대해서 간단히 소개해줍니다.
+- [Is Prisma an ORM?](https://www.prisma.io/docs/orm/overview/prisma-in-your-stack/is-prisma-an-orm): Prisma 공식문서에서 Prisma가 무엇인지, 어떤 원리로 작동되는지에 대해서 간단히 소개해줍니다.
     - [Prisma란?](https://velog.io/@hwisaac/Prisma-%EB%9E%80): 한글로도 짧게 정리한 블로그 글도 가져와봤습니다!
 
 ### 2. Prisma
 
 이제 ORM이 무엇이고, Prisma는 어떤 서비스인지 알아보았으니 구체적으로 어떻게 사용할 수 있는지 알아볼까요?
 
-- [What is Prisma?](https://www.prisma.io/docs/concepts/overview/what-is-prisma): Prisma의 작동 원리에 대해서 알아봅니다. 꼭 읽어봐주세요!! ⭐️
-- [Prisma schema](https://www.prisma.io/docs/concepts/components/prisma-schema): Prisma는 schema 파일을 통해 다양한 설정 정보를 얻고 어떠한 데이터 모델을 생성할지 파악합니다. schema 파일이 어떻게 구성되어 있고, 데이터 모델은 어떻게 작성할 수 있는지 살펴봐야겠죠? 😆
-- [Prisma CRUD](https://www.prisma.io/docs/concepts/components/prisma-client/crud): Prisma에서는 아주 많은.... 기능들이 있는데요, 이번에는 그중 실습때 쓰이는 CRUD관련 기능만 살펴봐주세요 🙂
+- [What is Prisma?](https://www.prisma.io/docs/orm/overview/introduction/what-is-prisma): Prisma의 작동 원리에 대해서 알아봅니다. 꼭 읽어봐주세요!! ⭐️
+- [Prisma schema](https://www.prisma.io/docs/orm/prisma-schema/overview): Prisma는 schema 파일을 통해 다양한 설정 정보를 얻고 어떠한 데이터 모델을 생성할지 파악합니다. schema 파일이 어떻게 구성되어 있고, 데이터 모델은 어떻게 작성할 수 있는지 살펴봐야겠죠? 😆
+- [Prisma CRUD](https://www.prisma.io/docs/orm/prisma-client/queries/crud): Prisma에서는 아주 많은.... 기능들이 있는데요, 이번에는 그중 실습때 쓰이는 CRUD관련 기능만 살펴봐주세요 🙂
 -  [Prisma Playground](https://playground.prisma.io): Prisma에서는 Playground를 통해 웹에서도 테스트할 수 있도록 해줘요! Playground를 통해 한 번 테스트해봐도 좋아요!
-    - [Prisma Client API reference](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference): API reference인데, 궁금하신 부분있으면 찾아봐도 괜찮을 것 같아요!
+    - [Prisma Client API reference](https://www.prisma.io/docs/orm/reference/prisma-client-reference): API reference인데, 궁금하신 부분있으면 찾아봐도 괜찮을 것 같아요!
 
 ## 프로젝트 실습 🎈
 


### PR DESCRIPTION
Prisma 스터디 가이드에서 기존 `Prisma 공식 Documnetation`의 링크가 변경되어 접속되지 않던 문제를 해결했습니다.

### 변경 사항
- Is Prisma an ORM?
- What is Prisma?
- Prisma schema
- Prisma CRUD
- Prisma Client API reference